### PR TITLE
project name fix

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ github_org             = "samsung-cnct"
 quay_org               = "samsung_cnct"
 publish_branch         = "master"
 image_tag              = "${env.RELEASE_VERSION}" != "null" ? "${env.RELEASE_VERSION}" : "latest"
-project_name           = "consul"
+project_name           = "consul-container"
 
 podTemplate(label: "${project_name}", containers: [
     containerTemplate(name: 'jnlp', image: "quay.io/${quay_org}/custom-jnlp:0.1", args: '${computer.jnlpmac} ${computer.name}'),


### PR DESCRIPTION
A consul container repo already exists due to an old project named consul which is being used. This breaks the convention a little bit, but we do not want to cause unforeseen problems with the existing repo, so we created a new one called consul-container and this project will use that repo.